### PR TITLE
Highlight Groups for Message Delineators 🌈

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -16,6 +16,13 @@
 
 ## Improvements
 
+- [ ] Add sqlite db for storing more data
+- [ ] Add token counts and costs stats
+
+- [ ] Add `@contexts`
+  + https://docs.cursor.com/en/context/@-symbols/overview
+  + https://github.com/yetone/avante.nvim/tree/main#mentions
+
 - [x] Refactor default config directory
   ~/.local/share/nvim/prompt/
 - [ ] Add initial user message delineator and placeholder text
@@ -24,28 +31,21 @@
   + [ ] Add indentation to all message blocks to enable folding
   + [ ] Collapse sequences of empty lines
   + [ ] Add custom markdown formatting
-    * [ ] delineators (by role)
+    * [x] delineators (by role)
     * [ ] message blocks
     * [ ] @contexts
-  + [ ] Add better reasoning formatting (highlight delineator line)
 - [ ] Update :PromptModelSelect to update models if cache expired
   + ~/.local/share/nvim/prompt/history/2025-07-19T09:19:23-agent-prompt-models-expiry.md
-- [ ] Add `@contexts`
-  + https://docs.cursor.com/en/context/@-symbols/overview
-  + https://github.com/yetone/avante.nvim/tree/main#mentions
 - [x] Add command to manually trigger summary rename
 - [ ] Add commands to navigate prompts by delineators (:PromptMessageNext, :PromptMessagePrev)
 - [ ] Add command to set config values at runtime (:PromptConfigSet)
 - [ ] Rename make_openrouter_request to make_chat_completion_request
 - [ ] Rename `get_prompt_summary` to `get_prompt_summary_filename`
 - [ ] Add more providers support
-- [ ] Add sqlite db for storing more data
-- [ ] Add token counts and costs stats
 - [ ] Enable multiple prompts simultaneously (just use files in history_dir, instead of a single shared buffer)
 - [ ] Enable sumbitting to multiple models simultaneously?
 - [ ] Model picker configurable format (select, filter, sort)
 - [ ] Add leaderboard sorting to model picker
 - [ ] Gracefully handle failed requests to out-of-date models
-- [ ] UI
 - [ ] Add "inline" prompts (meta+k) for code edits
 - [ ] Add agent mode?

--- a/TODO.md
+++ b/TODO.md
@@ -29,8 +29,9 @@
   + ~/.local/share/nvim/prompt_history/2025-07-19T09:19:23-agent-prompt-models-expiry.md
 - [ ] Add `@mentions`
   + https://github.com/yetone/avante.nvim/tree/main#mentions
-- [ ] Add command to manually trigger summary rename
+- [x] Add command to manually trigger summary rename
 - [ ] Add commands to navigate prompts by delineators (:PromptMessageNext, :PromptMessagePrev)
+- [ ] Add command to set config values at runtime (:PromptConfigSet)
 - [ ] Rename make_openrouter_request to make_chat_completion_request
 - [ ] Rename `get_prompt_summary` to `get_prompt_summary_filename`
 - [ ] Add more providers support

--- a/TODO.md
+++ b/TODO.md
@@ -23,11 +23,15 @@
   + [x] Add animated loading spinner
   + [ ] Add indentation to all message blocks to enable folding
   + [ ] Collapse sequences of empty lines
-  + [ ] Add custom markdown formatting (delineators, @mentions, reasoning)
+  + [ ] Add custom markdown formatting
+    * [ ] delineators (by role)
+    * [ ] message blocks
+    * [ ] @contexts
   + [ ] Add better reasoning formatting (highlight delineator line)
 - [ ] Update :PromptModelSelect to update models if cache expired
-  + ~/.local/share/nvim/prompt_history/2025-07-19T09:19:23-agent-prompt-models-expiry.md
-- [ ] Add `@mentions`
+  + ~/.local/share/nvim/prompt/history/2025-07-19T09:19:23-agent-prompt-models-expiry.md
+- [ ] Add `@contexts`
+  + https://docs.cursor.com/en/context/@-symbols/overview
   + https://github.com/yetone/avante.nvim/tree/main#mentions
 - [x] Add command to manually trigger summary rename
 - [ ] Add commands to navigate prompts by delineators (:PromptMessageNext, :PromptMessagePrev)

--- a/lua/prompt/commands.lua
+++ b/lua/prompt/commands.lua
@@ -1,10 +1,15 @@
 local core = require('prompt.core')
+local parse = require('prompt.parse')
 
 local M = {}
 
 ---Creates all the user commands for the prompt plugin
 function M.create_commands()
   local command = vim.api.nvim_create_user_command
+
+  command("PromptHighlight", function()
+    parse.add_highlights(vim.api.nvim_get_current_buf())
+  end, { desc = "Add Prompt highlights to current buffer" })
 
   command("PromptHistory", function()
     core.load_prompt_history()

--- a/lua/prompt/config.lua
+++ b/lua/prompt/config.lua
@@ -26,7 +26,7 @@ local M = {
       delineator_role = {},
     },
     reasoning = {
-      delineator_icon = { fg = "green" },
+      delineator_icon = {},
       delineator_line = { link = "DiagnosticVirtualTextHint" },
       delineator_role = {},
     },

--- a/lua/prompt/config.lua
+++ b/lua/prompt/config.lua
@@ -15,9 +15,9 @@
 ---@class PromptConfig
 local M = {
   highlight_groups = {
-    delineator_icon = { fg = "red" },
+    delineator_icon = { fg = "cyan" },
     delineator_line = { link = "DiagnosticVirtualTextInfo" },
-    delineator_role = { fg = "purple" },
+    delineator_role = {},
     delineator_spinner = { link = "ErrorMsg" },
   },
   history_date_format = "%Y-%m-%dT%H:%M:%S",

--- a/lua/prompt/config.lua
+++ b/lua/prompt/config.lua
@@ -2,6 +2,8 @@
 ---@alias Role "assistant"|"reasoning"|"user"
 
 ---@class PromptConfig
+---@field highlight_groups table<HighlightGroup, vim.api.keyset.highlight>
+---@field highlight_groups_by_role table<Role, table<HighlightGroup, vim.api.keyset.highlight>>
 ---@field history_date_format string
 ---@field history_dir string
 ---@field icons table<Role, string>
@@ -9,16 +11,30 @@
 ---@field model string
 ---@field models_path string
 ---@field spinner_chars string[]
----@field spinner_interval number
----@field highlight_groups table<HighlightGroup, vim.api.keyset.highlight>
+---@field spinner_interval number -- milliseconds
+---@field spinner_timeout number -- number of intervals, so duration = interval * timeout ms
 
 ---@class PromptConfig
 local M = {
   highlight_groups = {
-    delineator_icon = { fg = "cyan" },
-    delineator_line = { link = "DiagnosticVirtualTextInfo" },
-    delineator_role = {},
     delineator_spinner = { link = "ErrorMsg" },
+  },
+  highlight_groups_by_role = {
+    assistant = {
+      delineator_icon = { fg = "cyan" },
+      delineator_line = { link = "DiagnosticVirtualTextInfo" },
+      delineator_role = {},
+    },
+    reasoning = {
+      delineator_icon = { fg = "green" },
+      delineator_line = { link = "DiagnosticVirtualTextHint" },
+      delineator_role = {},
+    },
+    user = {
+      delineator_icon = { fg = "orange" },
+      delineator_line = { link = "DiagnosticVirtualTextWarn" },
+      delineator_role = {},
+    },
   },
   history_date_format = "%Y-%m-%dT%H:%M:%S",
   history_dir = "~/.local/share/nvim/prompt/history/",
@@ -32,12 +48,15 @@ local M = {
   models_path = "~/.local/share/nvim/prompt/models.json",
   spinner_chars = { "⠋", "⠙", "⠸", "⠴", "⠦", "⠇" },
   spinner_interval = 150,
+  spinner_timeout = 1000,
 }
 
 function M.setup_highlight_groups()
-  for group_name, attrs in pairs(M.highlight_groups) do
-    local hl_name = "Prompt" .. group_name:gsub("^%l", string.upper):gsub("_(%l)", function(c) return c:upper() end)
-    vim.api.nvim_set_hl(0, hl_name, attrs)
+  for role, groups in pairs(M.highlight_groups_by_role) do
+    for group_name, attrs in pairs(groups) do
+      local hl_name = "Prompt" .. role:gsub("^%l", string.upper) .. group_name:gsub("^%l", string.upper):gsub("_(%l)", function(c) return c:upper() end)
+      vim.api.nvim_set_hl(0, hl_name, attrs)
+    end
   end
 end
 

--- a/lua/prompt/config.lua
+++ b/lua/prompt/config.lua
@@ -1,15 +1,25 @@
+---@alias HighlightGroup "delineator_icon"|"delineator_line"|"delineator_role"|"delineator_spinner"
+---@alias Role "assistant"|"reasoning"|"user"
+
 ---@class PromptConfig
 ---@field history_date_format string
 ---@field history_dir string
----@field icons table<string, string>
+---@field icons table<Role, string>
 ---@field max_filename_length number
 ---@field model string
 ---@field models_path string
 ---@field spinner_chars string[]
 ---@field spinner_interval number
+---@field highlight_groups table<HighlightGroup, vim.api.keyset.highlight>
 
----@type PromptConfig
+---@class PromptConfig
 local M = {
+  highlight_groups = {
+    delineator_icon = { fg = "red" },
+    delineator_line = { link = "DiagnosticVirtualTextInfo" },
+    delineator_role = { fg = "purple" },
+    delineator_spinner = { link = "ErrorMsg" },
+  },
   history_date_format = "%Y-%m-%dT%H:%M:%S",
   history_dir = "~/.local/share/nvim/prompt/history/",
   icons = {
@@ -23,5 +33,12 @@ local M = {
   spinner_chars = { "⠋", "⠙", "⠸", "⠴", "⠦", "⠇" },
   spinner_interval = 150,
 }
+
+function M.setup_highlight_groups()
+  for group_name, attrs in pairs(M.highlight_groups) do
+    local hl_name = "Prompt" .. group_name:gsub("^%l", string.upper):gsub("_(%l)", function(c) return c:upper() end)
+    vim.api.nvim_set_hl(0, hl_name, attrs)
+  end
+end
 
 return M

--- a/lua/prompt/core.lua
+++ b/lua/prompt/core.lua
@@ -124,11 +124,9 @@ function M.load_prompt_history()
       return item.display
     end,
   }, function(choice)
-    if not choice then
-      return
-    end
-
+    if not choice then return end
     vim.cmd("e " .. choice.filepath)
+    parse.add_highlights(vim.api.nvim_get_current_buf())
   end)
 end
 

--- a/lua/prompt/init.lua
+++ b/lua/prompt/init.lua
@@ -19,6 +19,7 @@ function M.setup(opts)
     config = vim.tbl_deep_extend("force", config, opts)
   end
 
+  config.setup_highlight_groups()
   M.create_commands()
 end
 

--- a/lua/prompt/parse.lua
+++ b/lua/prompt/parse.lua
@@ -54,9 +54,12 @@ function M.add_delineator_highlights(args)
 
   config.setup_highlight_groups()
 
-  vim.api.nvim_buf_add_highlight(args.bufnr, -1, "PromptDelineatorLine", args.linenr, 0, line_end)
-  vim.api.nvim_buf_add_highlight(args.bufnr, -1, "PromptDelineatorIcon", args.linenr, icon_start - 1, icon_end)
-  vim.api.nvim_buf_add_highlight(args.bufnr, -1, "PromptDelineatorRole", args.linenr, role_start - 1, role_end)
+  local role_capitalized = (args.role == 'user' or args.role == 'reasoning')
+    and args.role:gsub("^%l", string.upper)
+    or 'Assistant'
+  vim.api.nvim_buf_add_highlight(args.bufnr, -1, "Prompt" .. role_capitalized .. "DelineatorLine", args.linenr, 0, line_end)
+  vim.api.nvim_buf_add_highlight(args.bufnr, -1, "Prompt" .. role_capitalized .. "DelineatorIcon", args.linenr, icon_start - 1, icon_end)
+  vim.api.nvim_buf_add_highlight(args.bufnr, -1, "Prompt" .. role_capitalized .. "DelineatorRole", args.linenr, role_start - 1, role_end)
 end
 
 ---@param bufnr number Buffer number to check

--- a/lua/prompt/parse.lua
+++ b/lua/prompt/parse.lua
@@ -40,6 +40,7 @@ function M.add_delineator_highlights(args)
     vim.notify("add_delineator_highlights: line is empty", vim.log.levels.ERROR)
     return
   end
+  local line_end = string.len(line)
   local icon_start, icon_end = string.find(line, args.icon, 1, true)
   if icon_start == nil or icon_end == nil then
     vim.notify("add_delineator_highlights: icon not found", vim.log.levels.ERROR)
@@ -53,7 +54,7 @@ function M.add_delineator_highlights(args)
 
   config.setup_highlight_groups()
 
-  vim.api.nvim_buf_add_highlight(args.bufnr, -1, "PromptDelineatorLine", args.linenr, 0, -1)
+  vim.api.nvim_buf_add_highlight(args.bufnr, -1, "PromptDelineatorLine", args.linenr, 0, line_end)
   vim.api.nvim_buf_add_highlight(args.bufnr, -1, "PromptDelineatorIcon", args.linenr, icon_start - 1, icon_end)
   vim.api.nvim_buf_add_highlight(args.bufnr, -1, "PromptDelineatorRole", args.linenr, role_start - 1, role_end)
 end

--- a/lua/prompt/spinner.lua
+++ b/lua/prompt/spinner.lua
@@ -83,9 +83,13 @@ function M.stop_spinner(bufnr)
   -- Stop the timer
   vim.fn.timer_stop(spinner_data.timer_id)
 
-  -- Restore the original line content
+  -- Remove the spinner content without destroying highlight groups on the rest of the line
   if vim.api.nvim_buf_is_valid(bufnr) then
-    vim.api.nvim_buf_set_lines(bufnr, spinner_data.line_num, spinner_data.line_num + 1, false, {spinner_data.original_line})
+    local start_row = spinner_data.line_num
+    local start_col = string.len(spinner_data.original_line)
+    local end_row = spinner_data.line_num
+    local end_col = start_col + (spinner_data.last_content_length or 0)
+    vim.api.nvim_buf_set_text(bufnr, start_row, start_col, end_row, end_col, {""})
   end
 
   M.active_spinners[bufnr] = nil

--- a/lua/prompt/spinner.lua
+++ b/lua/prompt/spinner.lua
@@ -60,7 +60,7 @@ function M.start_spinner(bufnr)
     spinner_data.char_index = (spinner_data.char_index % #config.spinner_chars) + 1
   end
 
-  local timer_id = vim.fn.timer_start(config.spinner_interval, update_spinner, {['repeat'] = 25})
+  local timer_id = vim.fn.timer_start(config.spinner_interval, update_spinner, {['repeat'] = config.spinner_timeout})
 
   M.active_spinners[bufnr] = {
     char_index = char_index,


### PR DESCRIPTION
Add configurable styles for message delineators

<img width="75%" alt="Screenshot 2025-07-31 at 8 53 36 PM" src="https://github.com/user-attachments/assets/0775eb92-e3de-4d71-abdd-6a7e25e21a32" />

<img width="35%" alt="Screenshot 2025-07-31 at 8 53 59 PM" src="https://github.com/user-attachments/assets/5afcc67c-f48d-4895-953c-8d95c8126812" />

Also changes message delineators to use full block digraphs instead of square brackets. I think these are a bit more unique and slightly more aesthetically appealing. 
The brackets were really just a temp solution to provide some color because MeanderingProgrammer/render-markdown.nvim plugin would render them as links, which looked nice, but not really the end solution.